### PR TITLE
Derive stream actions arguments from context

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-darwin-19
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Note: Usage in Rails
 
-In order to use `turbo-ruby` in Rails with the Rails `render` method you have to install the `phlex-rails` gem in your app. 
+In order to use `turbo-ruby` in Rails with the Rails `render` method you have to install the `phlex-rails` gem in your app.
 
 ### Regular Element
 
@@ -52,7 +52,7 @@ end.to_html
 
 ```html+erb
 <!-- Rails -->
-<%= render Turbo::Elements::TurboStream.new(action: "morph", target: "post_1", view_context: self, partial: "posts/post", locals: { post: @post } %>
+<%= render turbo.morph(@post, partial: "posts/post") %>
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -18,21 +18,19 @@ In order to use `turbo-ruby` in Rails with the Rails `render` method you have to
 
 ```ruby
 # Ruby
-Turbo::Elements::TurboStream.new(action: "console_log", message: "Hello World").to_html
+Turbo.stream(action: "console_log", message: "Hello World").to_html
 ```
 
 ```html+erb
 <!-- Rails -->
-<%= render Turbo::Elements::TurboStream.new(action: "console_log", message: "Hello World") %>
+<%= render Turbo.stream(action: "console_log", message: "Hello World") %>
 ```
-
-
 
 ### Blocks
 
 ```ruby
 # Ruby
-Turbo::Elements::TurboStream.new(action: "morph", target: "post_1") do
+Turbo.stream(action: "morph", target: "post_1") do
   %(<div id="post_id">
       <h1>Post 1</h1>
     </div>)
@@ -41,11 +39,44 @@ end.to_html
 
 ```html+erb
 <!-- Rails -->
-<%= render Turbo::Elements::TurboStream.new(action: "morph", target: "post_1") do %>
+<%= render Turbo.stream(action: "morph", target: "post_1") do %>
   <div id="post_id">
     <h1>Post 1</h1>
   </div>
 <% end %>
+```
+
+### Registering custom stream actions
+
+It's also possible to register custom stream actions:
+
+```ruby
+Turbo::Ruby.stream_actions do
+  # Can either register via the shorthand helper:
+  register :morph
+
+  def log(message, **options, &block)
+    stream(action: "console_log", message: message, **options, &block)
+  end
+
+  # Or define a custom action that must convert any positional arguments into the
+  # appropriate keyword arguments and must call `stream`.
+  def custom_action(*arguments, **options, &block)
+    stream(**options, &block)
+  end
+end
+```
+
+Now the examples from above can be:
+
+```ruby
+Turbo.log("Hello world").to_html
+
+Turbo.morph target: "post_1" do
+  %(<div id="post_id">
+    <h1>Post 1</h1>
+  </div>)
+end.to_html
 ```
 
 ### Partials (Rails only)

--- a/lib/turbo/elements/turbo_stream.rb
+++ b/lib/turbo/elements/turbo_stream.rb
@@ -39,7 +39,7 @@ module Turbo
           @view_context.capture(&block)
         elsif @rendering.any?
           throw "no view_context error" if @view_context.nil?
-          @view_context.render(formats: [:html], **@rendering)
+          @view_context.render(formats: [:html], object: @target, **@rendering)
         elsif @allow_inferred_rendering
           render_record(@target)
         end

--- a/lib/turbo/ruby.rb
+++ b/lib/turbo/ruby.rb
@@ -110,4 +110,4 @@ module Turbo
   end
 end
 
-require_relative "railtie" if defined?(Rails::Railtie)
+require_relative "ruby/railtie" if defined?(Rails::Railtie)

--- a/lib/turbo/ruby.rb
+++ b/lib/turbo/ruby.rb
@@ -10,5 +10,33 @@ require_relative "elements/turbo_frame"
 
 module Turbo
   module Ruby
+    module RegisteredStreamActions
+      def self.register(name, action = name)
+        define_method name do |*arguments, **options, &block|
+          stream(*arguments, action: action, **options, &block)
+        end
+      end
+
+      def stream(**options, &block)
+        Turbo::Elements::TurboStream.new(**options, &block)
+      end
+    end
+
+    class << self
+      def registered_stream_actions
+        RegisteredStreamActions
+      end
+
+      def stream_actions(&block)
+        registered_stream_actions.module_eval(&block)
+      end
+    end
+
+    stream_actions do
+      register :morph
+      register :log, "console_log"
+    end
   end
 end
+
+require_relative "railtie" if defined?(Rails::Railtie)

--- a/lib/turbo/ruby.rb
+++ b/lib/turbo/ruby.rb
@@ -10,30 +10,50 @@ require_relative "elements/turbo_frame"
 
 module Turbo
   module Ruby
-    module RegisteredStreamActions
+    module StreamActionsContext
       def self.register(name, action = name)
         define_method name do |*arguments, **options, &block|
           stream(*arguments, action: action, **options, &block)
         end
       end
 
-      def stream(view_context: view_context, **options, &block)
-        Turbo::Elements::TurboStream.new(view_context: view_context, **options, &block)
+      # turbo.targets(@posts).morph
+      def targets(targets)
+        if block_given?
+          targets.each { yield Turbo::Ruby::Target.new(self, _1) }
+        else
+          Turbo::Ruby::Targets.new(self, targets)
+        end
+      end
+      alias for targets # Turbo.for(@post).morph or Turbo.for(@posts).morph
+      alias call targets # Turbo.(@post).morph or Turbo.(@posts).morph
+
+      def target(record)
+        Turbo::Ruby::Target.new(self, record).tap { yield _1 if block_given? }
       end
 
-      def context
-        self
+      # <%= turbo.frame "post_1" do %>
+      # <% end %>
+      def frame(record)
+        Turbo::Elements::TurboFrame.new(to_dom_id(record)).tap { yield record if block_given? }
       end
-      delegate :view_context, to: :context
+
+      def to_dom_id(record)
+        record
+      end
+
+      def stream(**options, &block)
+        Turbo::Elements::TurboStream.new(**options, &block)
+      end
     end
 
     class << self
-      def registered_stream_actions
-        RegisteredStreamActions
+      def stream_actions_context
+        StreamActionsContext
       end
 
       def stream_actions(&block)
-        registered_stream_actions.module_eval(&block)
+        stream_actions_context.module_eval(&block)
       end
     end
 
@@ -47,7 +67,47 @@ module Turbo
   end
 
   # Make `Turbo.morph` etc. and `Turbo.stream` available.
-  include Ruby.registered_stream_actions
+  include Ruby.stream_actions_context
+
+  class Targets
+    include Turbo::Ruby.stream_actions_context
+
+    undef_method :targets
+    undef_method :target
+
+    def initialize(context, targets)
+      @context = context
+      @targets = targets.map { context.to_dom_id(_1) }
+    end
+
+    def frame(&block)
+      @targets.map { @context.frame(_1, &block) }
+    end
+
+    def stream(**options, &block)
+      @context.stream(targets: @targets, **options, &block)
+    end
+  end
+
+  class Target
+    include Turbo::Ruby.stream_actions_context
+
+    undef_method :targets
+    undef_method :target
+
+    def initialize(context, target)
+      @context = context
+      @target = context.to_dom_id(target)
+    end
+
+    def frame(&block)
+      @context.frame(@target, &block)
+    end
+
+    def stream(**options, &block)
+      @context.stream(target: @target, **options, &block)
+    end
+  end
 end
 
 require_relative "railtie" if defined?(Rails::Railtie)

--- a/lib/turbo/ruby.rb
+++ b/lib/turbo/ruby.rb
@@ -37,6 +37,9 @@ module Turbo
       register :log, "console_log"
     end
   end
+
+  # Make `Turbo.morph` etc. and `Turbo.stream` available.
+  include Ruby.registered_stream_actions
 end
 
 require_relative "railtie" if defined?(Rails::Railtie)

--- a/lib/turbo/ruby.rb
+++ b/lib/turbo/ruby.rb
@@ -34,7 +34,10 @@ module Turbo
 
     stream_actions do
       register :morph
-      register :log, "console_log"
+
+      def log(message, **options, &block)
+        stream(action: "console_log", message: message, **options, &block)
+      end
     end
   end
 

--- a/lib/turbo/ruby.rb
+++ b/lib/turbo/ruby.rb
@@ -17,9 +17,14 @@ module Turbo
         end
       end
 
-      def stream(**options, &block)
-        Turbo::Elements::TurboStream.new(**options, &block)
+      def stream(view_context: view_context, **options, &block)
+        Turbo::Elements::TurboStream.new(view_context: view_context, **options, &block)
       end
+
+      def context
+        self
+      end
+      delegate :view_context, to: :context
     end
 
     class << self

--- a/lib/turbo/ruby/context.rb
+++ b/lib/turbo/ruby/context.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Turbo
+  module Ruby
+    class Context
+      include Turbo::Ruby.registered_stream_actions
+
+      attr_reader :view_context
+
+      def initialize(view_context)
+        @view_context = view_context
+      end
+
+      # turbo.targets(@posts).morph
+      def targets(targets)
+        if block_given?
+          targets.each { yield Target.new(self, _1) }
+        else
+          Targets.new(self, targets)
+        end
+      end
+      alias for targets # turbo.for(@post).morph or turbo.for(@posts).morph
+      alias call targets # turbo.(@post).morph or turbo.(@posts).morph
+
+      def target(record)
+        Target.new(self, record).tap { yield _1 if block_given? }
+      end
+
+      # turbo.morph(@posts) or turbo.morph(@post)
+      def stream(records, **options, &block)
+        if records.respond_to?(:each)
+          super(targets: records, view_context: view_context, **options, &block)
+        else
+          super(target: records, view_context: view_context, **options, &block)
+        end
+      end
+
+      # <%= turbo.frame @post do %>
+      # <% end %>
+      def frame(record)
+        Turbo::Elements::TurboFrame.new(to_dom_id(record)).tap { yield record if block_given? }
+      end
+
+      def to_dom_id(record)
+        record.respond_to?(:to_key) ? @view_context.dom_id(record) : record
+      end
+
+      class Targets
+        include Turbo::Ruby.registered_stream_actions
+
+        def initialize(context, targets)
+          @context = context
+          @targets = targets.map { context.to_dom_id(_1) }
+        end
+
+        def frame(&block)
+          @targets.map { @context.frame(_1, &block) }
+        end
+
+        def stream(**options, &block)
+          super(targets: @targets, view_context: @context.view_context, **options, &block)
+        end
+      end
+
+      class Target
+        include Turbo::Ruby.registered_stream_actions
+
+        def initialize(context, target)
+          @context = context
+          @target = context.to_dom_id(target)
+        end
+
+        def frame(&block)
+          @context.frame(@target, &block)
+        end
+
+        def stream(**options, &block)
+          super(target: @target, view_context: @context.view_context, **options, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/turbo/ruby/context.rb
+++ b/lib/turbo/ruby/context.rb
@@ -29,9 +29,9 @@ module Turbo
       # turbo.morph(@posts) or turbo.morph(@post)
       def stream(records, **options, &block)
         if records.respond_to?(:each)
-          super(targets: records, view_context: view_context, **options, &block)
+          super(targets: records, **options, &block)
         else
-          super(target: records, view_context: view_context, **options, &block)
+          super(target: records, **options, &block)
         end
       end
 
@@ -48,6 +48,8 @@ module Turbo
       class Targets
         include Turbo::Ruby.registered_stream_actions
 
+        attr_reader :context
+
         def initialize(context, targets)
           @context = context
           @targets = targets.map { context.to_dom_id(_1) }
@@ -58,12 +60,14 @@ module Turbo
         end
 
         def stream(**options, &block)
-          super(targets: @targets, view_context: @context.view_context, **options, &block)
+          super(targets: @targets, **options, &block)
         end
       end
 
       class Target
         include Turbo::Ruby.registered_stream_actions
+
+        attr_reader :context
 
         def initialize(context, target)
           @context = context
@@ -75,7 +79,7 @@ module Turbo
         end
 
         def stream(**options, &block)
-          super(target: @target, view_context: @context.view_context, **options, &block)
+          super(target: @target, **options, &block)
         end
       end
     end

--- a/lib/turbo/ruby/context.rb
+++ b/lib/turbo/ruby/context.rb
@@ -3,7 +3,7 @@
 module Turbo
   module Ruby
     class Context
-      include Turbo::Ruby.registered_stream_actions
+      include Turbo::Ruby.stream_actions_context
 
       attr_reader :view_context
 
@@ -11,75 +11,16 @@ module Turbo
         @view_context = view_context
       end
 
-      # turbo.targets(@posts).morph
-      def targets(targets)
-        if block_given?
-          targets.each { yield Target.new(self, _1) }
-        else
-          Targets.new(self, targets)
-        end
-      end
-      alias for targets # turbo.for(@post).morph or turbo.for(@posts).morph
-      alias call targets # turbo.(@post).morph or turbo.(@posts).morph
-
-      def target(record)
-        Target.new(self, record).tap { yield _1 if block_given? }
+      def to_dom_id(record)
+        record.respond_to?(:to_key) ? view_context.dom_id(record) : record
       end
 
       # turbo.morph(@posts) or turbo.morph(@post)
       def stream(records, **options, &block)
         if records.respond_to?(:each)
-          super(targets: records, **options, &block)
+          super(targets: records, view_context: view_context, **options, &block)
         else
-          super(target: records, **options, &block)
-        end
-      end
-
-      # <%= turbo.frame @post do %>
-      # <% end %>
-      def frame(record)
-        Turbo::Elements::TurboFrame.new(to_dom_id(record)).tap { yield record if block_given? }
-      end
-
-      def to_dom_id(record)
-        record.respond_to?(:to_key) ? @view_context.dom_id(record) : record
-      end
-
-      class Targets
-        include Turbo::Ruby.registered_stream_actions
-
-        attr_reader :context
-
-        def initialize(context, targets)
-          @context = context
-          @targets = targets.map { context.to_dom_id(_1) }
-        end
-
-        def frame(&block)
-          @targets.map { @context.frame(_1, &block) }
-        end
-
-        def stream(**options, &block)
-          super(targets: @targets, **options, &block)
-        end
-      end
-
-      class Target
-        include Turbo::Ruby.registered_stream_actions
-
-        attr_reader :context
-
-        def initialize(context, target)
-          @context = context
-          @target = context.to_dom_id(target)
-        end
-
-        def frame(&block)
-          @context.frame(@target, &block)
-        end
-
-        def stream(**options, &block)
-          super(target: @target, **options, &block)
+          super(target: records, view_context: view_context, **options, &block)
         end
       end
     end

--- a/lib/turbo/ruby/railtie.rb
+++ b/lib/turbo/ruby/railtie.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Turbo
+  module Ruby
+    class Railtie < Rails::Railtie
+      initializer "turbo.ruby.view_helpers" do
+        ActiveSupport.on_load :action_view do
+          include Turbo::Ruby::ViewContextHelper
+        end
+      end
+    end
+  end
+end

--- a/lib/turbo/ruby/view_context_helper.rb
+++ b/lib/turbo/ruby/view_context_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Turbo
+  module Ruby
+    module ViewContextHelper
+      def turbo
+        @turbo ||= Turbo::Ruby::Context.new(self)
+      end
+    end
+  end
+end


### PR DESCRIPTION
First, we add a `turbo` helper in Rails views, so we can do:

```ruby
Turbo::Elements::TurboStream.new(action: "morph", target: "post_1", view_context: self, partial: "posts/post", locals: { post: @post })
turbo.stream action: "morph", target: "post_1", partial: "posts/post", locals: { post: @post }
```

Next, it's now possible to register custom stream actions, which are just shorthands:

```ruby
Turbo::Ruby.stream_actions do
  register :morph # Shorthand to define a method `morph` that calls `stream` behind the scenes.
end

turbo.morph target: "post_1", partial: "posts/post", locals: { post: @post }
```

There's also specific target contexts to help build stream actions.

```ruby
turbo.for(@posts).morph partial: "posts/post" # Will generate a `morph` action for each post.
turbo.target(@post) do |target|
  target.frame do
    target.stream action: "yolo"
  end
end
```

Note: we'll pass along `object:` when `**rendering`, so users can spare passing `locals:`:

```ruby
turbo.morph @post, partial: "posts/post"
```

There's also specific `frame` methods:

```ruby
turbo.frame @post
turbo.target(@post).frame
turbo.(@posts).frame do |post|
  # Generate a frame for each post, yielding it into the block.
end
```