### PR TITLE
Import `Turbo::Elements::TurboFrame` element from `phlex`

### DIFF
--- a/lib/turbo/elements/turbo_frame.rb
+++ b/lib/turbo/elements/turbo_frame.rb
@@ -4,6 +4,25 @@ module Turbo
   module Elements
     class TurboFrame < Phlex::HTML
       register_element :turbo_frame
+
+      def initialize(src:, loading:, disabled:, target:, autoscroll:)
+        @src = src
+        @loading = loading
+        @disabled = disabled
+        @target = target
+        @autoscroll = autoscroll
+      end
+
+      def template(&content)
+        turbo_frame(
+          src: @src,
+          loading: @loading,
+          disabled: @disabled,
+          target: @target,
+          autoscroll: @autoscroll,
+          &content
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Joel removed the Turbo elements from Phlex in this pull request:  https://github.com/joeldrapper/phlex/pull/426

We are just going to take over the Turbo frame element to have something to  start with.

Closes #3 